### PR TITLE
Fix bug in tree build function

### DIFF
--- a/src/tree.py
+++ b/src/tree.py
@@ -16,6 +16,8 @@ class TreeBuilder(RegressorBuilder):
         node_cnts = np.zeros(self.n_nodes_leafs) # num of images in each node
         node_buckets = np.zeros(self.n_nodes_leafs,dtype=object) # dividing images into two parts in each node
         node_buckets[0] = (0, len(targets))
+        node_cnts[0] = len(targets)
+        node_sums[0] = targets.sum(axis=0)
         best_splits = []
         permute = np.arange(0, len(targets), dtype=int) # permute order of pixel 
         

--- a/src/util.py
+++ b/src/util.py
@@ -65,7 +65,7 @@ def fit_shape_to_box(normal_shape, box):
     center_y = y + h/2.0
 
     shape = normal_shape.points - normal_shape.centre()
-    shape *= [0.9*h/2.0, 0.9*w/2.0]
+    shape *= [0.9*w/2.0, 0.9*h/2.0]
     shape += [center_x, center_y]
 
     return PointCloud(shape)


### PR DESCRIPTION
First commit:
When buid tree function call find_best_split, there is no sum of targets and number of targets in root node. Therefore, left_sum will be -right_sum and lcnt = -rcnt.

Second commit:
Only swapped variable "w" and "h" because w belongs to variable x and h belongs to variable y. Anyway, there is more places in the code where variable x indicates y-coordinate because in Menpo library, the first coordinate is y-coordinate not x.